### PR TITLE
Make all spinner objects in CLI of class Spinner, not Halo

### DIFF
--- a/jigsaw/cli.py
+++ b/jigsaw/cli.py
@@ -116,7 +116,7 @@ if user_confirms(message="Would you like to upload the dataset to S3?"):
     bucket = user_input(
         message="Which bucket would you like to upload to?",
         default=os.environ["DATASETS_BUCKET_NAME"])
-    spinner = Halo(text="Uploading dataset to S3...", text_color="magenta")
+    spinner = Spinner(text="Uploading dataset to S3...", text_color="magenta")
     spinner.start()
     upload_dataset(
         bucket_name=bucket, directory=Path.cwd() / 'dataset' / dataset_name)


### PR DESCRIPTION
Get rid of accidental creation of Halo (not Spinner) object in cli.py now that Halo is not being imported in the module.

Fixes #26 